### PR TITLE
fix: describe Xero API errors in tool responses instead of [object Object]

### DIFF
--- a/src/Middlewares/ErrorMiddleware.ts
+++ b/src/Middlewares/ErrorMiddleware.ts
@@ -1,14 +1,15 @@
+import { describeError } from "../Utils/describeError.js";
 import { IRequestMiddleware } from "./IRequestMiddleware.js";
 
 export const ErrorMiddleware: IRequestMiddleware = async (request, next) => {
   try {
     return await next(request);
-  } catch (error: any) {
+  } catch (error: unknown) {
     return {
       content: [
         {
           type: "text",
-          text: `Unexpected error occurred: ${error}`,
+          text: `Unexpected error occurred: ${describeError(error)}`,
         },
       ],
     };

--- a/src/Utils/describeError.test.ts
+++ b/src/Utils/describeError.test.ts
@@ -1,0 +1,59 @@
+import { describeError } from "./describeError.js";
+
+const BEARER = "Bearer eyJhbGciOiJSUzI1NiJ9.super-secret-access-token";
+
+describe("describeError", () => {
+  it("summarises a xero-node validation rejection without the bearer token", () => {
+    const rejection = {
+      response: {
+        statusCode: 400,
+        statusMessage: "Bad Request",
+        request: { headers: { authorization: BEARER, "xero-tenant-id": "tenant" } },
+        headers: { "www-authenticate": BEARER },
+        body: {
+          ErrorNumber: 10,
+          Type: "ValidationException",
+          Message: "A validation exception occurred",
+          Elements: [
+            { ValidationErrors: [{ Message: "Name is required" }, { Message: "Email is invalid" }] },
+          ],
+        },
+      },
+      body: {},
+    };
+
+    const text = describeError(rejection);
+
+    expect(text).toBe(
+      "Xero API 400 Bad Request: A validation exception occurred; Name is required; Email is invalid"
+    );
+    expect(text).not.toContain(BEARER);
+    expect(text).not.toContain("authorization");
+  });
+
+  it("summarises an expired-token rejection", () => {
+    const text = describeError({
+      response: {
+        statusCode: 401,
+        body: { Title: "Unauthorized", Status: 401, Detail: "TokenExpired: token expired at 2026-09-06" },
+      },
+      body: null,
+    });
+    expect(text).toBe("Xero API 401: Unauthorized; TokenExpired: token expired at 2026-09-06");
+  });
+
+  it("falls back to the status alone when the body has no message", () => {
+    expect(describeError({ response: { statusCode: 429 }, body: undefined })).toBe("Xero API 429");
+  });
+
+  it("never reads token-like keys from an arbitrary object", () => {
+    const text = describeError({ headers: { authorization: BEARER }, access_token: BEARER });
+    expect(text).toBe("Xero API error");
+  });
+
+  it("passes Error messages and strings through", () => {
+    expect(describeError(new Error("boom"))).toBe("boom");
+    expect(describeError("plain string")).toBe("plain string");
+    expect(describeError(undefined)).toBe("undefined");
+  });
+});

--- a/src/Utils/describeError.ts
+++ b/src/Utils/describeError.ts
@@ -1,0 +1,62 @@
+/**
+ * Render a thrown value as text for a tool response without serialising it.
+ *
+ * xero-node rejects a failed API call with a plain `{ response, body }`
+ * object, not an Error. Interpolating it prints "[object Object]", and
+ * JSON.stringify would copy `response.request.headers.authorization`, the
+ * caller's bearer token, into the text returned to the model. Only the
+ * status code and human-readable message fields are read here.
+ */
+
+const MESSAGE_KEYS = new Set(["message", "detail", "title", "error", "error_description"]);
+const SKIP_KEYS = /^(request|config|headers|rawHeaders|req|socket|connection|authorization|token|access_token|refresh_token|id_token)$/i;
+const MAX_DEPTH = 6;
+const MAX_MESSAGES = 10;
+const MAX_LENGTH = 500;
+
+export function describeError(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error.slice(0, MAX_LENGTH);
+  if (!error || typeof error !== "object") return String(error);
+
+  const { response, body } = error as {
+    response?: { statusCode?: unknown; statusMessage?: unknown; body?: unknown };
+    body?: unknown;
+  };
+
+  let status = "Xero API error";
+  if (typeof response?.statusCode === "number") {
+    status = `Xero API ${response.statusCode}`;
+    if (typeof response.statusMessage === "string" && response.statusMessage) {
+      status += ` ${response.statusMessage}`;
+    }
+  }
+
+  const messages: string[] = [];
+  collectMessages(response?.body, messages, 0);
+  if (messages.length === 0) collectMessages(body, messages, 0);
+  if (messages.length === 0) return status;
+  return `${status}: ${messages.join("; ")}`.slice(0, MAX_LENGTH);
+}
+
+function collectMessages(value: unknown, out: string[], depth: number): void {
+  if (out.length >= MAX_MESSAGES || depth > MAX_DEPTH) return;
+  if (typeof value === "string") {
+    if (depth === 0 && value.trim()) out.push(value.trim());
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectMessages(item, out, depth + 1);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (SKIP_KEYS.test(key)) continue;
+    if (MESSAGE_KEYS.has(key.toLowerCase()) && typeof child === "string" && child.trim()) {
+      if (!out.includes(child.trim())) out.push(child.trim());
+    } else {
+      collectMessages(child, out, depth + 1);
+    }
+    if (out.length >= MAX_MESSAGES) return;
+  }
+}


### PR DESCRIPTION
xero-node rejects a failed API call with a plain `{ response, body }` object, so `ErrorMiddleware` returned `Unexpected error occurred: [object Object]` for every 4xx: validation failures on the create and update tools, expired tokens, missing scopes. The model got no usable detail. `JSON.stringify` is not the repair, because `response.request.headers.authorization` holds the caller's bearer token.

`describeError` reads only the status code and message-like fields (`Message`, `Detail`, `Title`, `ValidationErrors`) from the raw response body, skips request, header and token keys by name, and caps the length. Tests cover a validation rejection carrying a bearer token, an expired-token body, a bare status, an arbitrary object with token keys, and plain `Error` and string throws.

`npm test` (37 passing) and `npm run build` pass.
